### PR TITLE
If the backend sends a no-cache header - respect that.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,10 @@ This can be done by using the following example vcl:
 		set beresp.http.X-Url = req.url;
 		set beresp.http.X-Host = req.http.host;
 		set beresp.http.X-Cache-TTL = beresp.ttl;
+		
+		if (beresp.http.cache-control ~ "no-cache") {
+			return(hit_for_pass);
+		}
 	}
 
 	sub vcl_deliver {


### PR DESCRIPTION
This is necessary, because the extension will not send the specific cache headers if the request is marked as uncached.
Without these headers, the cache invalidation doesnt work due to missing X-Site header and others.
