### PR TITLE
[BUGFIX] Normalize tag names for banning

### DIFF
--- a/Classes/MOC/Varnish/Service/VarnishBanService.php
+++ b/Classes/MOC/Varnish/Service/VarnishBanService.php
@@ -93,6 +93,9 @@ class VarnishBanService {
 		if (count($this->settings['ignoredCacheTags']) > 0) {
 			$tags = array_diff($tags, $this->settings['ignoredCacheTags']);
 		}
+		$tags = str_replace(':', '-', $tags);
+		$tags = str_replace('.', '_', $tags);
+
 		// Set specific domain before invalidating tags
 		if ($domain !== NULL) {
 			$this->varnishProxyClient->setDefaultBanHeader(ProxyClient\Varnish::HTTP_HEADER_HOST, $domain);


### PR DESCRIPTION
Neos: 2.0.5
MOC.Varnish: 2.0.5

Banning by tags is currently broken.

The X-Cache-Tags header (browser) contains "NodeType_TYPO3_Neos-Document", but the BAN-Request tries to ban "NodeType_TYPO3.Neos:Document" which does not work.
