### PR TITLE
[BUGFIX] Site token changes after flushing caches

### DIFF
--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -7,3 +7,4 @@ Moc_Varnish_Site_Token:
   backend: TYPO3\Flow\Cache\Backend\SimpleFileBackend
   backendOptions:
     cacheDirectory: '%FLOW_PATH_DATA%Persistent/MocVarnishSiteToken'
+  persistent: true


### PR DESCRIPTION
After flushing caches the site token changes and cache invalidation fails
