### PR TITLE
TASK: Migrate "typoScriptPath" to "fusionPath"

### DIFF
--- a/Classes/Aspects/ContentCacheAspect.php
+++ b/Classes/Aspects/ContentCacheAspect.php
@@ -41,9 +41,9 @@ class ContentCacheAspect
         $runtime = ObjectAccess::getProperty($proxy, 'runtime', true);
 
         if ($evaluateContext['cacheForPathDisabled']) {
-            $mocVarnishIgnoreUncached = $runtime->evaluate($evaluateContext['typoScriptPath'] . '/__meta/cache/mocVarnishIgnoreUncached');
+            $mocVarnishIgnoreUncached = $runtime->evaluate($evaluateContext['fusionPath'] . '/__meta/cache/mocVarnishIgnoreUncached');
             if ($mocVarnishIgnoreUncached !== true) {
-                $this->logger->log(sprintf('Varnish cache disabled due to uncached path "%s" (can be prevented using "mocVarnishIgnoreUncached")', $evaluateContext['typoScriptPath']), LOG_DEBUG);
+                $this->logger->log(sprintf('Varnish cache disabled due to uncached path "%s" (can be prevented using "mocVarnishIgnoreUncached")', $evaluateContext['fusionPath']), LOG_DEBUG);
                 $this->evaluatedUncached = true;
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "neos/neos": "^3.0",
+        "neos/neos": "~3.0.4 || ^3.1.2",
         "friendsofsymfony/http-cache": "~1.3"
     },
     "autoload": {


### PR DESCRIPTION
As Neos 3.0 starting from the version 3.0.4/3.1.2 uses now "fusionPath" instead of "typoScriptPath".

Without this Fix, the Neos Backend throws this error:

    Undefined index: typoScriptPath in [...] /Data/Temporary/Development/Cache/Code/Flow_Object_Classes/MOC_Varnish_Aspects_ContentCacheAspect.php line 46