### PR TITLE
BUGFIX: Rename typoScriptPath to fusionPath in aspect class

### DIFF
--- a/Classes/Aspects/ContentCacheAspect.php
+++ b/Classes/Aspects/ContentCacheAspect.php
@@ -41,9 +41,9 @@ class ContentCacheAspect
         $runtime = ObjectAccess::getProperty($proxy, 'runtime', true);
 
         if ($evaluateContext['cacheForPathDisabled']) {
-            $mocVarnishIgnoreUncached = $runtime->evaluate($evaluateContext['typoScriptPath'] . '/__meta/cache/mocVarnishIgnoreUncached');
+            $mocVarnishIgnoreUncached = $runtime->evaluate($evaluateContext['fusionPath'] . '/__meta/cache/mocVarnishIgnoreUncached');
             if ($mocVarnishIgnoreUncached !== true) {
-                $this->logger->log(sprintf('Varnish cache disabled due to uncached path "%s" (can be prevented using "mocVarnishIgnoreUncached")', $evaluateContext['typoScriptPath']), LOG_DEBUG);
+                $this->logger->log(sprintf('Varnish cache disabled due to uncached path "%s" (can be prevented using "mocVarnishIgnoreUncached")', $evaluateContext['fusionPath']), LOG_DEBUG);
                 $this->evaluatedUncached = true;
             }
         }


### PR DESCRIPTION
The (internal) array key was renamed in Neos versions 3.1.2 and 3.0.4,
leading to an error because of an undefined index being used.