### PR TITLE
TASK: Compatibility with Neos 3.2+

### DIFF
--- a/Classes/Cache/MetadataAwareStringFrontend.php
+++ b/Classes/Cache/MetadataAwareStringFrontend.php
@@ -58,7 +58,7 @@ class MetadataAwareStringFrontend extends StringFrontend
     /**
      * {@inheritdoc}
      */
-    public function getByTag($tag)
+    public function getByTag($tag): array
     {
         $entries = parent::getByTag($tag);
         foreach ($entries as $identifier => $content) {

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "neos/neos": "~3.0.4 || ^3.1.2",
+        "neos/neos": "^3.2",
         "friendsofsymfony/http-cache": "~1.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         }
     ],
     "require": {
+        "php": ">=7.0",
         "neos/neos": "~3.0.4 || ^3.1.2",
         "friendsofsymfony/http-cache": "~1.3"
     },


### PR DESCRIPTION
An `@api` method from `Neos.Cache` was changed in Flow 4.2 breaking backwards compatibility,
so a version requiring Neos 3.2+ adjusted to the changed method is needed.