### PR TITLE
BUGFIX: Fix method headers in MetadataAwareStringFrontend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.0
+  - 7.2
 
 before_script:
   - env
@@ -16,13 +16,13 @@ before_script:
           "bin-dir": "bin"
       },
       "require": {
-          "neos/neos": "^3.0",
+          "neos/neos": "^4.0",
           "moc/varnish": "${VERSION}"
       },
       "require-dev": {
-          "typo3/buildessentials": "~4.0",
+          "neos/buildessentials": "~5.0",
           "mikey179/vfsstream": "~1.6",
-          "phpunit/phpunit": "~5.4.0"
+          "phpunit/phpunit": "~7.1.0"
       },
       "scripts": {
           "post-update-cmd": "Neos\\\\Flow\\\\Composer\\\\InstallerScripts::postUpdateAndInstall",

--- a/Classes/Cache/MetadataAwareStringFrontend.php
+++ b/Classes/Cache/MetadataAwareStringFrontend.php
@@ -37,7 +37,7 @@ class MetadataAwareStringFrontend extends StringFrontend
      *
      * {@inheritdoc}
      */
-    public function set($entryIdentifier, $content, array $tags = array(), $lifetime = null)
+    public function set(string $entryIdentifier, $content, array $tags = [], int $lifetime = null)
     {
         $content = $this->insertMetadata($content, $entryIdentifier, $tags, $lifetime);
         parent::set($entryIdentifier, $content, $tags, $lifetime);
@@ -46,7 +46,7 @@ class MetadataAwareStringFrontend extends StringFrontend
     /**
      * {@inheritdoc}
      */
-    public function get($entryIdentifier)
+    public function get(string $entryIdentifier)
     {
         $content = parent::get($entryIdentifier);
         if ($content !== false) {
@@ -58,7 +58,7 @@ class MetadataAwareStringFrontend extends StringFrontend
     /**
      * {@inheritdoc}
      */
-    public function getByTag($tag): array
+    public function getByTag(string $tag): array
     {
         $entries = parent::getByTag($tag);
         foreach ($entries as $identifier => $content) {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "neos/neos": ">3.2",
+        "neos/neos": ">4.0",
         "friendsofsymfony/http-cache": "~1.3"
     },
     "autoload": {


### PR DESCRIPTION
In order to be compatible with Flow 5.0 the method headers need to be adjusted.