### PR TITLE
FEATURE: Support for Workspaces Hashes in Cache Tags introduced in Neos 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "neos/neos": ">4.0",
+        "neos/neos": ">4.1",
         "friendsofsymfony/http-cache": "~1.3"
     },
     "autoload": {


### PR DESCRIPTION
Resolves #41 

@aertmann i don't have time to implement the check if `renderWorkspaceTagForContextNode` exists to keep compatibility to Neos 4.0 atm, but feel free to change the PR as needed.