### PR TITLE
FEATURE: Allow configuration of maximum varnish request header length

### DIFF
--- a/Classes/Service/VarnishBanService.php
+++ b/Classes/Service/VarnishBanService.php
@@ -69,7 +69,7 @@ class VarnishBanService
         $this->varnishProxyClient = new ProxyClient\Varnish($varnishUrls);
         $this->varnishProxyClient->setDefaultBanHeader('X-Site', $this->tokenStorage->getToken());
         $this->cacheInvalidator = new CacheInvalidator($this->varnishProxyClient);
-        $this->tagHandler = new TagHandler($this->cacheInvalidator);
+        $this->tagHandler = new TagHandler($this->cacheInvalidator, 'X-Cache-Tags', $this->settings['maximumHeaderLength'] ?? 7500);
     }
 
     /**

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -11,6 +11,10 @@ MOC:
       defaultSharedMaximumAge: null
       # Disable sending headers (useful for staging environments)
       disabled: false
+
+    # Maximum length of header in bytes for requests to varnish. Used when banning. Large requests will be split across multiple smaller ones
+    maximumHeaderLength: 7500
+
     # Port to use for reverse lookup in backend module
     reverseLookupPort: null
     # List of ignored  cache tags to skip when flushing caches by tag, e.g. 'TYPO3.Neos:Document' which is used in 'TYPO3.Neos:Menu' elements


### PR DESCRIPTION
If a page with a huge number of tags is flushed, varnish might deny
the requests if the header is too large. By setting the headerLength
in the TagHandler, large requests will be split into multiple smaller
ones. 7500 is used as default value, as that is the default value
of the TagHandler if none is specified.