### PR TITLE
BUGFIX: Cast flash message to string

### DIFF
--- a/Classes/Controller/VarnishCacheController.php
+++ b/Classes/Controller/VarnishCacheController.php
@@ -172,7 +172,7 @@ class VarnishCacheController extends AbstractModuleController
         }
         $service = new VarnishBanService();
         $service->banAll($domains, $contentType);
-        $this->addFlashMessage((string) new Message(sprintf('All varnish cache cleared for %s%s', $site ? 'site ' . $site->getName() : 'installation', $contentType ? ' with content type "' . $contentType . '"' : '')));
+        $this->addFlashMessage(sprintf('All varnish cache cleared for %s%s', $site ? 'site ' . $site->getName() : 'installation', $contentType ? ' with content type "' . $contentType . '"' : ''));
         $this->redirect('index');
     }
 

--- a/Classes/Controller/VarnishCacheController.php
+++ b/Classes/Controller/VarnishCacheController.php
@@ -172,7 +172,7 @@ class VarnishCacheController extends AbstractModuleController
         }
         $service = new VarnishBanService();
         $service->banAll($domains, $contentType);
-        $this->addFlashMessage(new Message(sprintf('All varnish cache cleared for %s%s', $site ? 'site ' . $site->getName() : 'installation', $contentType ? ' with content type "' . $contentType . '"' : '')));
+        $this->addFlashMessage((string) new Message(sprintf('All varnish cache cleared for %s%s', $site ? 'site ' . $site->getName() : 'installation', $contentType ? ' with content type "' . $contentType . '"' : '')));
         $this->redirect('index');
     }
 


### PR DESCRIPTION
When purging content cache for a certain content type (ex. text/css) you will get the following exception after the purging is done

Exception #1243258395 in line 175 of /var/www/website/Data/Temporary/Production/Cache/Code/Flow_Object_Classes/MOC_Varnish_Controller_VarnishCacheController.php: The message body must be of type string, "object" given. - See also: 20200513062504a2ac87.txt

This is due to a Object being passed to the flashMessage.

This change cast it to a string (using the __toString) method of the Message object

Resolves: #50 