### PR TITLE
Cache Control header

### DIFF
--- a/Classes/Http/CacheControlHeaderComponent.php
+++ b/Classes/Http/CacheControlHeaderComponent.php
@@ -121,7 +121,7 @@ class CacheControlHeaderComponent implements ComponentInterface
         $nodeLifetime = $node->getProperty('cacheTimeToLive');
 
         if ($nodeLifetime === '' || $nodeLifetime === null) {
-            $defaultLifetime = $this->settings['cacheHeaders']['defaultSharedMaximumAge'] ?? null;
+            $defaultLifetime = $this->cacheHeaderSettings['cacheHeaders']['defaultSharedMaximumAge'] ?? null;
             $timeToLive = $defaultLifetime;
             if ($defaultLifetime === null) {
                 $timeToLive = $cacheLifetime;

--- a/Classes/Http/CacheControlHeaderComponent.php
+++ b/Classes/Http/CacheControlHeaderComponent.php
@@ -129,7 +129,7 @@ class CacheControlHeaderComponent implements ComponentInterface
         }
 
         if ($timeToLive !== null) {
-            // $response->setSharedMaximumAge((int)$timeToLive);
+            $modifiedResponse = $modifiedResponse->withAddedHeader('Cache-Control', sprintf('public, s-maxage=%d', $timeToLive));
             $this->logger->debug(sprintf('Varnish cache enabled for node "%s" (%s) with max-age "%u"', $node->getLabel(), $node->getPath(), $timeToLive), LogEnvironment::fromMethodName(__METHOD__));
         } else {
             $this->logger->debug(sprintf('Varnish cache headers not sent for node "%s" (%s) due to no max-age', $node->getLabel(), $node->getPath()), LogEnvironment::fromMethodName(__METHOD__));


### PR DESCRIPTION
Hey guys!

first of all, thanks for this package! :heart: 

I discovered two bugs in this package regarding the cache control header. Currently this package does not generate any cache control header. So the varnish server does not cache anything, which made it a little bit useless. 

I think this is just a mistake, because before this commit (ee4951c) all cache control headers has been set correctly and the old code has just be commented out. 