### PR TITLE
FEATURE: Update to fos/http-cache:~2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
           "bin-dir": "bin"
       },
       "require": {
-          "neos/neos": "^4.0",
+          "neos/neos": "^5.0",
           "moc/varnish": "${VERSION}"
       },
       "require-dev": {

--- a/Classes/Http/CacheControlHeaderComponent.php
+++ b/Classes/Http/CacheControlHeaderComponent.php
@@ -109,7 +109,7 @@ class CacheControlHeaderComponent implements ComponentInterface
         list($tags, $cacheLifetime) = $this->getCacheTagsAndLifetime();
 
         if (count($tags) > 0) {
-            $modifiedResponse = $modifiedResponse->withHeader('X-Cache-Tags', $tags);
+            $modifiedResponse = $modifiedResponse->withHeader('X-Cache-Tags', implode(',', $tags));
         }
 
         $modifiedResponse = $modifiedResponse->withHeader('X-Site', $this->tokenStorage->getToken());

--- a/Classes/Service/ProxyClient/Varnish.php
+++ b/Classes/Service/ProxyClient/Varnish.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace MOC\Varnish\Service\ProxyClient;
+
+use FOS\HttpCache\ProxyClient\Varnish as FOSVarnish;
+
+/**
+ * Varnish ProxyClient that allows banning by tags and hosts
+ * at the same time
+ */
+class Varnish extends FOSVarnish
+{
+
+    /**
+     * @var array
+     */
+    private $hosts = [];
+
+    public function forHosts(string ... $hosts): self
+    {
+        $this->hosts = $hosts;
+
+        return $this;
+    }
+
+    public function ban(array $headers)
+    {
+        $headers = array_merge(
+            $this->getHostHeader(),
+            $headers
+        );
+
+        return parent::ban($headers);
+    }
+
+    private function getHostHeader(): array
+    {
+        switch (count($this->hosts)) {
+            case 0:
+                return [];
+            case 1:
+                return [self::HTTP_HEADER_HOST => current($this->hosts)];
+            default:
+                return [self::HTTP_HEADER_HOST => '^(' . implode('|', $this->hosts) . ')$'];
+        }
+    }
+
+}

--- a/Classes/Service/VarnishBanService.php
+++ b/Classes/Service/VarnishBanService.php
@@ -45,10 +45,9 @@ class VarnishBanService
     protected $cacheInvalidator;
 
     /**
-     * @var TagHandler
+     * @param array $settings
+     * @return void
      */
-    protected $tagHandler;
-
     public function injectSettings(array $settings): void
     {
         $this->settings = $settings;
@@ -61,10 +60,14 @@ class VarnishBanService
         array_walk($varnishUrls, function (&$varnishUrl) {
             $varnishUrl = rtrim($varnishUrl, '/');
         });
-        $this->varnishProxyClient = new ProxyClient\Varnish($varnishUrls);
-        $this->varnishProxyClient->setDefaultBanHeader('X-Site', $this->tokenStorage->getToken());
+        $httpDispatcher = new FOS\HttpCache\ProxyClient\HttpDispatcher($varnishUrls, '');
+        $options = [
+            'default_ban_headers' => [
+                "X-Site" => $this->tokenStorage->getToken()
+            ]
+        ];
+        $this->varnishProxyClient = new Varnish($httpDispatcher, $options);
         $this->cacheInvalidator = new CacheInvalidator($this->varnishProxyClient);
-        $this->tagHandler = new TagHandler($this->cacheInvalidator, 'X-Cache-Tags', $this->settings['maximumHeaderLength'] ?? 7500);
     }
 
     /**
@@ -81,8 +84,8 @@ class VarnishBanService
      */
     public function banAll($domains = null, $contentType = null): void
     {
-        $this->cacheInvalidator->invalidateRegex('.*', $contentType, $domains);
-        $this->logger->debug(sprintf('Clearing all Varnish cache%s%s', $domains ? ' for domains "' . (is_array($domains) ? implode(', ', $domains) : $domains) . '"' : '', $contentType ? ' with content type "' . $contentType . '"' : ''));
+        $this->cacheInvalidator->invalidate($this->getHostHeader($domains))->invalidateRegex('.*', $contentType, $domains);
+        $this->logger->debug(sprintf('Cleared all Varnish cache%s%s', $domains ? ' for domains "' . (is_array($domains) ? implode(', ', $domains) : $domains) . '"' : '', $contentType ? ' with content type "' . $contentType . '"' : ''));
         $this->execute();
     }
 
@@ -113,15 +116,8 @@ class VarnishBanService
         }
 
         // Set specific domain before invalidating tags
-        if ($domains) {
-            $this->varnishProxyClient->setDefaultBanHeader(ProxyClient\Varnish::HTTP_HEADER_HOST, is_array($domains) ? '^(' . implode('|', $domains) . ')$' : $domains);
-        }
-        $this->tagHandler->invalidateTags($tags);
-        // Unset specific domain after invalidating tags
-        if ($domains) {
-            $this->varnishProxyClient->setDefaultBanHeader(ProxyClient\Varnish::HTTP_HEADER_HOST, ProxyClient\Varnish::REGEX_MATCH_ALL);
-        }
-        $this->logger->debug(sprintf('Clearing Varnish cache for tags "%s"%s', implode(',', $tags), $domains ? ' for domains "' . (is_array($domains) ? implode(', ', $domains) : $domains) . '"' : ''));
+        $this->cacheInvalidator->invalidate($this->getHostHeader($domains))->invalidateTags($tags);
+        $this->logger->debug(sprintf('Cleared Varnish cache for tags "%s"%s', implode(',', $tags), $domains ? ' for domains "' . (is_array($domains) ? implode(', ', $domains) : $domains) . '"' : ''));
         $this->execute();
     }
 
@@ -140,5 +136,12 @@ class VarnishBanService
                 }
             }
         }
+    }
+
+    private function getHostHeader($domains = null)
+    {
+        return ($domains !== null) ? [
+            ProxyClient\Varnish::HTTP_HEADER_HOST => is_array($domains) ? '^(' . implode('|', $domains) . ')$' : $domains
+        ] : [];
     }
 }

--- a/Classes/Service/VarnishBanService.php
+++ b/Classes/Service/VarnishBanService.php
@@ -61,9 +61,9 @@ class VarnishBanService
         });
         $httpDispatcher = new ProxyClient\HttpDispatcher($varnishUrls);
         $options = [
+            'header_length' => $this->settings['maximumHeaderLength'] ?? 7500,
             'default_ban_headers' => [
-                'X-Site' => $this->tokenStorage->getToken(),
-                'header_length' => $this->settings['maximumHeaderLength'] ?? 7500
+                'X-Site' => $this->tokenStorage->getToken()
             ]
         ];
         $this->varnishProxyClient = new ProxyClient\Varnish($httpDispatcher, $options);

--- a/Classes/Service/VarnishBanService.php
+++ b/Classes/Service/VarnishBanService.php
@@ -7,7 +7,6 @@ use FOS\HttpCache\CacheInvalidator;
 use FOS\HttpCache\Exception\ExceptionCollection;
 use FOS\HttpCache\Exception\ProxyResponseException;
 use FOS\HttpCache\Exception\ProxyUnreachableException;
-use FOS\HttpCache\Handler\TagHandler;
 use FOS\HttpCache\ProxyClient;
 use Neos\Flow\Annotations as Flow;
 
@@ -60,13 +59,14 @@ class VarnishBanService
         array_walk($varnishUrls, function (&$varnishUrl) {
             $varnishUrl = rtrim($varnishUrl, '/');
         });
-        $httpDispatcher = new FOS\HttpCache\ProxyClient\HttpDispatcher($varnishUrls, '');
+        $httpDispatcher = new ProxyClient\HttpDispatcher($varnishUrls);
         $options = [
             'default_ban_headers' => [
-                "X-Site" => $this->tokenStorage->getToken()
+                'X-Site' => $this->tokenStorage->getToken(),
+                'header_length' => $this->settings['maximumHeaderLength'] ?? 7500
             ]
         ];
-        $this->varnishProxyClient = new Varnish($httpDispatcher, $options);
+        $this->varnishProxyClient = new ProxyClient\Varnish($httpDispatcher, $options);
         $this->cacheInvalidator = new CacheInvalidator($this->varnishProxyClient);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     ],
     "require": {
         "neos/neos": "^5.0",
-        "friendsofsymfony/http-cache": "~1.3"
+        "friendsofsymfony/http-cache": "~2.0",
+        "php-http/curl-client": "~1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This aims to get #46 in a working state so MOC.Varnish can be used together with Neos 5. Currently `moc/varnish` cannot be installed: 
```
  Problem 1
    - Conclusion: don't install moc/varnish 4.0.1
    - Conclusion: remove symfony/console v4.4.9
    - Installation request for moc/varnish ^4.0 -> satisfiable by moc/varnish[4.0.0, 4.0.1].
    - Conclusion: don't install symfony/console v4.4.9
    - moc/varnish 4.0.0 requires friendsofsymfony/http-cache ~1.3 -> satisfiable by friendsofsymfony/http-cache[1.3.0, 1.3.1, 1.3.2, 1.4.0, 1.4.1, 1.4.2, 1.4.3, 1.4.4, 1.4.5, 1.4.6].
    - friendsofsymfony/http-cache 1.3.0 requires symfony/event-dispatcher ~2.3 -> satisfiable by symfony/event-dispatcher
```

This patch also cleans up some mistakes that lead to the package being broken for Neos 5.X.