### PR TITLE
FEATURE: Add option to use short md5 for cache tags

### DIFF
--- a/Classes/Http/CacheControlHeaderComponent.php
+++ b/Classes/Http/CacheControlHeaderComponent.php
@@ -5,6 +5,7 @@ namespace Moc\Varnish\Http;
 
 use MOC\Varnish\Aspects\ContentCacheAspect;
 use MOC\Varnish\Cache\MetadataAwareStringFrontend;
+use MOC\Varnish\Service\CacheTagService;
 use MOC\Varnish\Service\TokenStorage;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Annotations as Flow;
@@ -48,6 +49,12 @@ class CacheControlHeaderComponent implements ComponentInterface
      * @Flow\Inject
      */
     protected $propertyMapper;
+
+    /**
+     * @var CacheTagService
+     * @Flow\Inject
+     */
+    protected $cacheTagService;
 
     /**
      * @var MetadataAwareStringFrontend
@@ -109,7 +116,8 @@ class CacheControlHeaderComponent implements ComponentInterface
         list($tags, $cacheLifetime) = $this->getCacheTagsAndLifetime();
 
         if (count($tags) > 0) {
-            $modifiedResponse = $modifiedResponse->withHeader('X-Cache-Tags', implode(',', $tags));
+            $shortenedTags = $this->cacheTagService->shortenTags($tags);
+            $modifiedResponse = $modifiedResponse->withHeader('X-Cache-Tags', implode(',', $shortenedTags));
         }
 
         $modifiedResponse = $modifiedResponse->withHeader('X-Site', $this->tokenStorage->getToken());

--- a/Classes/Service/CacheTagService.php
+++ b/Classes/Service/CacheTagService.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace MOC\Varnish\Service;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class CacheTagService
+{
+
+    /**
+     * @var int
+     * @Flow\InjectConfiguration(path="cacheHeaders")
+     */
+    protected $cacheHeaderConfiguration;
+
+    /**
+     * @see \Neos\Fusion\Core\Cache\ContentCache::sanitizeTags()
+     *
+     * @param array $tags
+     * @return array
+     */
+    public function sanitizeTags(array $tags): array
+    {
+        return array_map(function (string $tag) {
+            return strtr($tag, '.:', '_-');
+        }, $tags);
+    }
+
+    /**
+     * Generate short md5 for cache tags if enabled
+     *
+     * See these two configuration options:
+     * * MOC.Varnish.cacheHeaders.shortenCacheTags
+     * * MOC.Varnish.cacheHeaders.cacheTagLength
+     *
+     * @param array $tags
+     * @return array
+     */
+    public function shortenTags(array $tags = []): array
+    {
+        if (!$this->shouldShortenTags()) {
+            return $tags;
+        }
+
+        return array_map(function (string $tag) {
+            return substr(md5($tag), 0, (int)$this->cacheHeaderConfiguration['cacheTagLength'] ?? 8);
+        }, $tags);
+    }
+
+    protected function shouldShortenTags(): bool
+    {
+        return (bool)$this->cacheHeaderConfiguration['shortenCacheTags'] ?? false;
+    }
+
+}

--- a/Classes/Service/ContentCacheFlusherService.php
+++ b/Classes/Service/ContentCacheFlusherService.php
@@ -111,8 +111,7 @@ class ContentCacheFlusherService
                 if ($nodeInWorkspace === null) {
                     break;
                 }
-                $tagName = 'DescendantOf_' . $workspaceHash . '_' . $nodeInWorkspace->getIdentifier();
-                $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node "%s" has changed.', $tagName, $node->getPath());
+                $this->generateCacheTagsForDescendantOf($workspaceHash . '_' . $nodeInWorkspace->getIdentifier());
             }
         }
 
@@ -133,8 +132,17 @@ class ContentCacheFlusherService
      */
     protected function generateCacheTagsForNodeIdentifier(string $cacheIdentifier): void
     {
-        $this->tagsToFlush['Node_' . $cacheIdentifier] = sprintf('which were tagged with "Node_%s" because that identifier has changed.', $cacheIdentifier);
+        $tagName = 'Node_' . $cacheIdentifier;
+        $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node identifier "%s" has changed.', $tagName, $cacheIdentifier);
         // Note, as we don't have a node here we cannot go up the structure.
+        $this->generateCacheTagsForDescendantOf($cacheIdentifier);
+    }
+
+    /**
+     * @param string $cacheIdentifier
+     */
+    protected function generateCacheTagsForDescendantOf(string $cacheIdentifier): void
+    {
         $tagName = 'DescendantOf_' . $cacheIdentifier;
         $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node "%s" has changed.', $tagName, $cacheIdentifier);
     }
@@ -154,7 +162,8 @@ class ContentCacheFlusherService
             $nodeTypePrefix = rtrim($nodeTypePrefix, '_') . '_';
         }
         foreach ($nodeTypesToFlush as $nodeTypeNameToFlush) {
-            $this->tagsToFlush['NodeType_' . $nodeTypePrefix . $nodeTypeNameToFlush] = sprintf('which were tagged with "NodeType_%s" because node "%s" has changed and was of type "%s".', $nodeTypeNameToFlush, ($referenceNodeIdentifier ? $referenceNodeIdentifier : ''), $nodeTypeName);
+            $tagName = 'NodeType_' . $nodeTypePrefix . $nodeTypeNameToFlush;
+            $this->tagsToFlush[$tagName] = sprintf('which were tagged with "%s" because node "%s" has changed and was of type "%s".', $tagName, $referenceNodeIdentifier ?: '', $nodeTypeName);
         }
     }
 

--- a/Classes/Service/VarnishBanService.php
+++ b/Classes/Service/VarnishBanService.php
@@ -30,6 +30,12 @@ class VarnishBanService
     protected $tokenStorage;
 
     /**
+     * @Flow\Inject
+     * @var CacheTagService
+     */
+    protected $cacheTagService;
+
+    /**
      * @var array
      */
     protected $settings;
@@ -109,13 +115,8 @@ class VarnishBanService
             $tags = array_diff($tags, $this->settings['ignoredCacheTags']);
         }
 
-        /**
-         * Sanitize tags
-         * @see \Neos\Fusion\Core\Cache\ContentCache
-         */
-        foreach ($tags as $key => $tag) {
-            $tags[$key] = strtr($tag, '.:', '_-');
-        }
+        $tags = $this->cacheTagService->sanitizeTags($tags);
+        $tags = $this->cacheTagService->shortenTags($tags);
 
         $this->varnishProxyClient->forHosts(...$this->domainsToArray($domains));
         $this->cacheInvalidator->invalidateTags($tags);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,10 +6,14 @@ MOC:
     varnishUrl: 'http://127.0.0.1'
     # Cache header sending configuration
     cacheHeaders:
-      # Default and maximum TTL in seconds
-      defaultSharedMaximumAge: null
       # Disable sending headers (useful for staging environments)
       disabled: false
+      # Default and maximum TTL in seconds
+      defaultSharedMaximumAge: null
+      # Enable shortening of Cache Tags (useful when response headers get too large)
+      shortenCacheTags: false
+      # Length of the short md5 if shortenCacheTags is enabled
+      cacheTagLength: 8
 
     # Maximum length of header in bytes for requests to varnish. Used when banning. Large requests will be split across multiple smaller ones
     maximumHeaderLength: 7500

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -19,6 +19,10 @@ There are several configuration options can/needs to be set:
    If not set, the Varnish configuration needs to cache by default since no ``Cache-Control`` header will be sent
 - Disable sending of cache headers - can be used to disable Varnish on staging environment e.g.
    ``MOC.Varnish.cacheHeaders.disabled`` accepts boolean value (defaults to ``FALSE``)
+- Since 4.1.0: The generated Cache Tags can be shortened using this option
+   ``MOC.Varnish.cacheHeaders.shortenCacheTags`` accepts boolean value (defaults to ``FALSE``)
+- Since 4.1.0: If shortenCacheTags is enabled, this option controls the length of the used md5 for tags
+   ``MOC.Varnish.cacheHeaders.cacheTagLength`` accepts integer value (defaults to ``8``)
 - Reverse lookup port can be set to allow debugging in the backend module if the web server port is not ``80``
    ``MOC.Varnish.reverseLookupPort`` accepts integer (defaults to ``NULL``)
 - Ignored cache tags can be used to ignore certain cache tags from being cleared at all (useful for optimizing)


### PR DESCRIPTION
Since Neos 4.1, the Fusion cache tags contain a hash of the workspace a node is in (eg. `Node_%d0dbe915091d400bd8ee7f27f0791303%_06be94b9-dacf-49a7-98f5-98c57d5d5d2a`). Because of this the `X-Cache-Tags` header can get quite big, leading to problems with Varnish or nginx caused by the huge HTTP Header.

This patch adds an option to shrink these cache tags by using a substring of their md5 with configurable length, drastically decreasing the required size for including the cache tags.
