### PR TITLE
TASK: Removing building tags for the workspace chain

### DIFF
--- a/Classes/Middleware/CacheControlHeaderComponent.php
+++ b/Classes/Middleware/CacheControlHeaderComponent.php
@@ -156,6 +156,7 @@ class CacheControlHeaderComponent implements MiddlewareInterface
         $lifetime = null;
         $tags = [];
         $entriesMetadata = $this->contentCacheFrontend->getAllMetadata();
+
         foreach ($entriesMetadata as $identifier => $metadata) {
             $entryTags = $metadata['tags'] ?? [];
             $entryLifetime = $metadata['lifetime'] ?? null;


### PR DESCRIPTION
In contrast to the fusion cache, the varnish cache implementation only
caches live content.

This means we only need to consider the live context when sending
tags to flush caches.

The reduces the amount of tags tremendously when having a lot
of workspaces.