### PR TITLE
FEATURE: Add configuration to send a debug header to varnish

### DIFF
--- a/Classes/Middleware/CacheControlHeaderComponent.php
+++ b/Classes/Middleware/CacheControlHeaderComponent.php
@@ -143,6 +143,10 @@ class CacheControlHeaderComponent implements MiddlewareInterface
             $this->logger->debug(sprintf('Varnish cache headers not sent for node "%s" (%s) due to no max-age', $node->getLabel(), $node->getPath()), LogEnvironment::fromMethodName(__METHOD__));
         }
 
+        if ($this->cacheHeaderSettings['debug'] ?? false) {
+            $response = $response->withAddedHeader('X-Cache-Debug', '1');
+        }
+
         return $response;
     }
 

--- a/Configuration/Development/Settings.yaml
+++ b/Configuration/Development/Settings.yaml
@@ -1,0 +1,4 @@
+Flowpack:
+  Varnish:
+    cacheHeaders:
+      debug: true

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,10 +2,14 @@ Flowpack:
   Varnish:
     # Disables Varnish caching if set to false
     enabled: true
+
     # URL or URLs (if array) Varnish is running on for purge requests (skip trailing slash)
     varnishUrl: 'http://127.0.0.1'
+
     # Cache header sending configuration
     cacheHeaders:
+      # If enabled, sends an "X-Cache-Debug" to varnish to output additional header information
+      debug: false
       # Disable sending headers (useful for staging environments)
       disabled: false
       # Default and maximum TTL in seconds


### PR DESCRIPTION
This can be used in VCL to conditionally remove the header in vcl_deliver:

```
    if (!resp.http.X-Cache-Debug) {
        unset resp.http.Via;
        unset resp.http.X-Varnish;

        unset resp.http.X-Cache-Tags;
        unset resp.http.X-Cache-TTL;
        unset resp.http.X-Site;
        unset resp.http.X-URL;
    }
```