### PR TITLE
FEATURE: Allow comma separated values for varnish backends

### DIFF
--- a/Classes/Service/VarnishBanService.php
+++ b/Classes/Service/VarnishBanService.php
@@ -152,11 +152,9 @@ class VarnishBanService
         $varnishUrls = $this->settings['varnishUrl'] ?? ['http://127.0.0.1'];
 
         if (is_string($varnishUrls)) {
-            if (strpos($varnishUrls, ',') > 0) {
-                $varnishUrls = explode(',', $varnishUrls);
-            } else {
-                $varnishUrls = [$varnishUrls];
-            }
+            $varnishUrls = array_filter(explode(',', $varnishUrls));
+        } else {
+            $varnishUrls = [$varnishUrls];
         }
 
         // Remove trailing slash as it will break the Varnish ProxyClient

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,7 +3,7 @@ Flowpack:
     # Disables Varnish caching if set to false
     enabled: true
 
-    # URL or URLs (if array) Varnish is running on for purge requests (skip trailing slash)
+    # URL or URLs as comma separated value or array, Varnish is running on for purge requests (skip trailing slash)
     varnishUrl: 'http://127.0.0.1'
 
     # Cache header sending configuration


### PR DESCRIPTION
This can be used, to pass a list of varnish servers given from an
environment variable.