### PR TITLE
BUGFIX: Don't flush if tags is an empty array

### DIFF
--- a/Classes/Aspects/ContentCacheAspect.php
+++ b/Classes/Aspects/ContentCacheAspect.php
@@ -129,8 +129,10 @@ class ContentCacheAspect
     public function interceptContentCacheFlush(JoinPointInterface $joinPoint)
     {
         $object = $joinPoint->getProxy();
-
         $tags = array_keys(ObjectAccess::getProperty($object, 'tagsToFlush', true));
+        if ($tags === []) {
+          return;
+        }
 
         $this->varnishBanService->banByTags($tags);
     }


### PR DESCRIPTION
FOS Varnish will call array_chunk on the given tags with the size of the tags array. If the tags are empty, an error is thrown.